### PR TITLE
GEOPY-1698: relock conda env on new geoapps-utils

### DIFF
--- a/environments/py-3.10-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.10-linux-64-dev.conda.lock.yml
@@ -4,13 +4,14 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - astroid=3.2.4=py310hff52083_0
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.32.2=h4bc722e_0
+  - c-ares=1.32.3=h4bc722e_0
   - ca-certificates=2024.7.4=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -32,7 +33,7 @@ dependencies:
   - libaec=1.1.3=h59595ed_0
   - libblas=3.9.0=23_linux64_openblas
   - libcblas=3.9.0=23_linux64_openblas
-  - libcurl=8.8.0=hca28451_1
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
@@ -63,7 +64,7 @@ dependencies:
   - openssl=3.3.1=h4bc722e_2
   - packaging=24.1=pyhd8ed1ab_0
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
   - pthread-stubs=0.4=h36c2ea0_1001
@@ -71,13 +72,13 @@ dependencies:
   - pydantic-core=2.20.1=py310h42e942d_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pylint=3.2.6=pyhd8ed1ab_0
-  - pytest=8.3.1=pyhd8ed1ab_0
+  - pytest=8.3.2=pyhd8ed1ab_0
   - pytest-cov=5.0.0=pyhd8ed1ab_0
   - python=3.10.14=hd12c33a_0_cpython
   - python_abi=3.10=4_cp310
   - readline=8.2=h8228510_1
   - scipy=1.14.0=py310h93e2701_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - toml=0.10.2=pyhd8ed1ab_0
   - tomli=2.0.1=pyhd8ed1ab_0
@@ -91,8 +92,8 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-linux-64.conda.lock.yml
+++ b/environments/py-3.10-linux-64.conda.lock.yml
@@ -4,12 +4,13 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.32.2=h4bc722e_0
+  - c-ares=1.32.3=h4bc722e_0
   - ca-certificates=2024.7.4=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
@@ -25,7 +26,7 @@ dependencies:
   - libaec=1.1.3=h59595ed_0
   - libblas=3.9.0=23_linux64_openblas
   - libcblas=3.9.0=23_linux64_openblas
-  - libcurl=8.8.0=hca28451_1
+  - libcurl=8.9.1=hdb1bdb2_0
   - libdeflate=1.20=hd590300_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=hd590300_2
@@ -54,7 +55,7 @@ dependencies:
   - openjpeg=2.5.2=h488ebb8_0
   - openssl=3.3.1=h4bc722e_2
   - pillow=10.3.0=py310hebfe307_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pthread-stubs=0.4=h36c2ea0_1001
   - pydantic=2.8.2=pyhd8ed1ab_0
   - pydantic-core=2.20.1=py310h42e942d_0
@@ -62,7 +63,7 @@ dependencies:
   - python_abi=3.10=4_cp310
   - readline=8.2=h8228510_1
   - scipy=1.14.0=py310h93e2701_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - tk=8.6.13=noxft_h4845f30_101
   - typing-extensions=4.12.2=hd8ed1ab_0
   - typing_extensions=4.12.2=pyha770c72_0
@@ -73,8 +74,8 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - zstd=1.5.6=ha6fb4c9_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64-dev.conda.lock.yml
+++ b/environments/py-3.10-win-64-dev.conda.lock.yml
@@ -4,6 +4,7 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - astroid=3.2.4=py310h5588dad_0
@@ -28,7 +29,7 @@ dependencies:
   - libaec=1.1.3=h63175ca_0
   - libblas=3.9.0=23_win64_mkl
   - libcblas=3.9.0=23_win64_mkl
-  - libcurl=8.8.0=hd5e4a3a_1
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libffi=3.4.2=h8ffe710_5
   - libhwloc=2.11.1=default_h8125262_1000
@@ -56,7 +57,7 @@ dependencies:
   - openssl=3.3.1=h2466b09_2
   - packaging=24.1=pyhd8ed1ab_0
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - platformdirs=4.2.2=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
   - pthread-stubs=0.4=hcd874cb_1001
@@ -65,12 +66,12 @@ dependencies:
   - pydantic-core=2.20.1=py310hc226416_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pylint=3.2.6=pyhd8ed1ab_0
-  - pytest=8.3.1=pyhd8ed1ab_0
+  - pytest=8.3.2=pyhd8ed1ab_0
   - pytest-cov=5.0.0=pyhd8ed1ab_0
   - python=3.10.14=h4de0772_0_cpython
   - python_abi=3.10=4_cp310
   - scipy=1.14.0=py310h46043a1_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - tbb=2021.12.0=hc790b64_3
   - tk=8.6.13=h5226925_1
   - toml=0.10.2=pyhd8ed1ab_0
@@ -89,8 +90,8 @@ dependencies:
   - xz=5.2.6=h8d14728_0
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64.conda.lock.yml
+++ b/environments/py-3.10-win-64.conda.lock.yml
@@ -4,6 +4,7 @@
 
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - bzip2=1.0.8=h2466b09_7
@@ -21,7 +22,7 @@ dependencies:
   - libaec=1.1.3=h63175ca_0
   - libblas=3.9.0=23_win64_mkl
   - libcblas=3.9.0=23_win64_mkl
-  - libcurl=8.8.0=hd5e4a3a_1
+  - libcurl=8.9.1=h18fefc2_0
   - libdeflate=1.20=hcfcfb64_0
   - libffi=3.4.2=h8ffe710_5
   - libhwloc=2.11.1=default_h8125262_1000
@@ -47,7 +48,7 @@ dependencies:
   - openjpeg=2.5.2=h3d672ee_0
   - openssl=3.3.1=h2466b09_2
   - pillow=10.3.0=py310h3e38d90_1
-  - pip=24.0=pyhd8ed1ab_0
+  - pip=24.2=pyhd8ed1ab_0
   - pthread-stubs=0.4=hcd874cb_1001
   - pthreads-win32=2.9.1=hfa6e2cd_3
   - pydantic=2.8.2=pyhd8ed1ab_0
@@ -55,7 +56,7 @@ dependencies:
   - python=3.10.14=h4de0772_0_cpython
   - python_abi=3.10=4_cp310
   - scipy=1.14.0=py310h46043a1_1
-  - setuptools=71.0.4=pyhd8ed1ab_0
+  - setuptools=72.1.0=pyhd8ed1ab_0
   - tbb=2021.12.0=hc790b64_3
   - tk=8.6.13=h5226925_1
   - typing-extensions=4.12.2=hd8ed1ab_0
@@ -71,8 +72,8 @@ dependencies:
   - xz=5.2.6=h8d14728_0
   - zstd=1.5.6=h0ea2cb4_0
   - pip:
-      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
-      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+      - geoapps-utils @ git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
+      - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
 
 variables:
   KMP_WARNINGS: 0

--- a/py-3.10.conda-lock.yml
+++ b/py-3.10.conda-lock.yml
@@ -20,6 +20,8 @@ metadata:
   channels:
   - url: conda-forge
     used_env_vars: []
+  - url: nodefaults
+    used_env_vars: []
   platforms:
   - win-64
   - linux-64
@@ -82,8 +84,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
     typing-extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/astroid-3.2.4-py310hff52083_0.conda
   hash:
@@ -96,8 +98,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
     typing-extensions: '>=4.0.0'
   url: https://conda.anaconda.org/conda-forge/win-64/astroid-3.2.4-py310h5588dad_0.conda
   hash:
@@ -110,8 +112,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
   hash:
     md5: 62ee74e96c5ebb0af99386de58cf9553
@@ -123,8 +125,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
   hash:
@@ -133,16 +135,16 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.32.2
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.2-h4bc722e_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
   hash:
-    md5: 8024af1ee7078e37fa3101c0a0296af2
-    sha256: d1b01f9e3d10b97fd09e19fda0caf9bfad3c884a6b19fb3f654a9aed02a70b58
+    md5: 7624e34ee6baebfc80d67bac76cc9d9d
+    sha256: 3c5a844bb60b0d52d89c3f1bd828c9856417fe33a6102fd8bbd5c13c3351704a
   category: main
   optional: false
 - name: ca-certificates
@@ -244,11 +246,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
     tomli: ''
+    libgcc-ng: '>=12'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    __glibc: '>=2.17,<3.0.a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.0-py310h5b4e0ec_0.conda
   hash:
     md5: a13d72c877b47870042897a0e667cd3a
@@ -260,12 +262,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
     tomli: ''
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.0-py310ha8f682b_0.conda
   hash:
     md5: 03ace5584d20b0c6c547f5f4c0a08a51
@@ -303,9 +305,9 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    numpy: '>=1.22.4,<2.0a0'
     scipy: '>=1.8'
   url: https://conda.anaconda.org/conda-forge/linux-64/discretize-0.10.0-py310hcb52e73_1.conda
   hash:
@@ -318,13 +320,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    scipy: '>=1.8'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    numpy: '>=1.22.4,<2.0a0'
+    scipy: '>=1.8'
   url: https://conda.anaconda.org/conda-forge/win-64/discretize-0.10.0-py310h4856b71_1.conda
   hash:
     md5: 7af88a12920a5b2b5ae459a5dd032019
@@ -361,8 +363,8 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   hash:
     md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
@@ -374,11 +376,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   hash:
     md5: 3761b23693f768dc75a8fd0a73ca053f
@@ -391,11 +393,11 @@ package:
   platform: linux-64
   dependencies:
     cached-property: ''
-    hdf5: '>=1.14.3,<1.14.4.0a0'
     libgcc-ng: '>=12'
-    numpy: '>=1.19,<3'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    numpy: '>=1.19,<3'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.11.0-nompi_py310hf054cd7_102.conda
   hash:
     md5: f74f9a0a4d713f5eec89917883f4ae7e
@@ -408,13 +410,13 @@ package:
   platform: win-64
   dependencies:
     cached-property: ''
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    numpy: '>=1.19,<3'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    numpy: '>=1.19,<3'
+    hdf5: '>=1.14.3,<1.14.4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/h5py-3.11.0-nompi_py310h2b0be38_102.conda
   hash:
     md5: 6ea1515f0984ae6e916cc1f124e6b664
@@ -426,14 +428,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libgcc-ng: '>=12'
     libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0a0'
+    libgfortran5: '>=12.3.0'
     openssl: '>=3.3.1,<4.0a0'
+    libzlib: '>=1.2.13,<2.0a0'
+    libcurl: '>=8.8.0,<9.0a0'
+    libaec: '>=1.1.3,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
   hash:
     md5: 7e1729554e209627636a0f6fabcdd115
@@ -445,13 +447,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libaec: '>=1.1.3,<2.0a0'
-    libcurl: '>=8.8.0,<9.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    openssl: '>=3.3.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    openssl: '>=3.3.1,<4.0a0'
+    libzlib: '>=1.2.13,<2.0a0'
+    libcurl: '>=8.8.0,<9.0a0'
+    libaec: '>=1.1.3,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
   hash:
     md5: 5788de34381caf624b78c4981618dc0a
@@ -498,8 +500,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8,<4.0'
     setuptools: ''
+    python: '>=3.8,<4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_0.conda
   hash:
     md5: 1d25ed2b95b92b026aaa795eabec8d91
@@ -536,11 +538,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    keyutils: '>=1.6.1,<2.0a0'
-    libedit: '>=3.1.20191231,<4.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     openssl: '>=3.3.1,<4.0a0'
+    libedit: '>=3.1.20191231,<4.0a0'
+    keyutils: '>=1.6.1,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   hash:
     md5: 3f43953b7d3fb3aaa1d0d0723d91e368
@@ -552,10 +554,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    openssl: '>=3.3.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    openssl: '>=3.3.1,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
   hash:
     md5: 31aec030344e962fbd7dbbbbd68e60a9
@@ -581,11 +583,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
   hash:
     md5: d3592435917b62a8becff3a60db674f6
@@ -647,8 +649,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
   hash:
@@ -661,7 +663,7 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.27,<1.0a0'
+    libopenblas: '>=0.3.27,<0.3.28.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
   hash:
     md5: 96c8450a40aa2b9733073a9460de972c
@@ -705,38 +707,38 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.8.0
+  version: 8.9.1
   manager: conda
   platform: linux-64
   dependencies:
-    krb5: '>=1.21.3,<1.22.0a0'
     libgcc-ng: '>=12'
-    libnghttp2: '>=1.58.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.3.1,<4.0a0'
     zstd: '>=1.5.6,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
+    libssh2: '>=1.11.0,<2.0a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+    libnghttp2: '>=1.58.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.1-hdb1bdb2_0.conda
   hash:
-    md5: b8afb3e3cb3423cc445cf611ab95fdb0
-    sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
+    md5: 7da1d242ca3591e174a3c7d82230d3c0
+    sha256: 0ba60f83709068e9ec1ab543af998cb5a201c8379c871205447684a34b5abfd8
   category: main
   optional: false
 - name: libcurl
-  version: 8.8.0
+  version: 8.9.1
   manager: conda
   platform: win-64
   dependencies:
-    krb5: '>=1.21.3,<1.22.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<2.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.8.0-hd5e4a3a_1.conda
+    libzlib: '>=1.3.1,<2.0a0'
+    libssh2: '>=1.11.0,<2.0a0'
+    krb5: '>=1.21.3,<1.22.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.1-h18fefc2_0.conda
   hash:
-    md5: 88fbd2ea44690c6dfad8737659936461
-    sha256: ebe665ec226672e7e6e37f2b1fe554db83f9fea5267cbc5a849ab34d8546b2c3
+    md5: 099a1016d23baa4f41148a985351a7a8
+    sha256: 024be133aed5f100c0b222761e747cc27a2bdf94af51947ad5f70e88cf824988
   category: main
   optional: false
 - name: libdeflate
@@ -756,8 +758,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
   hash:
@@ -820,8 +822,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
+    _libgcc_mutex: '0.1'
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
   hash:
     md5: ca0fad6a41ddaef54a153b78eccb5037
@@ -869,11 +871,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libxml2: '>=2.12.7,<3.0a0'
     pthreads-win32: ''
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libxml2: '>=2.12.7,<3.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
   hash:
     md5: 933bad6e4658157f1aec9b171374fde2
@@ -885,8 +887,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
   hash:
@@ -911,8 +913,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
   hash:
@@ -949,12 +951,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.23.0,<2.0a0'
-    libev: '>=4.33,<5.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<2.0.0a0'
     openssl: '>=3.2.0,<4.0a0'
+    libev: '>=4.33,<5.0a0'
+    c-ares: '>=1.23.0,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
   hash:
     md5: 700ac6ea6d53d5510591c4344d5c989a
@@ -978,8 +980,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
     libgfortran-ng: ''
+    libgcc-ng: '>=12'
     libgfortran5: '>=12.3.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
   hash:
@@ -1005,10 +1007,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
   hash:
     md5: 77e398acc32617a0384553aea29e866b
@@ -1033,8 +1035,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
   hash:
@@ -1061,11 +1063,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
+    vc14_runtime: '>=14.29.30139'
     libzlib: '>=1.2.13,<2.0.0a0'
     openssl: '>=3.1.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
   hash:
     md5: dc262d03aae04fe26825062879141a41
@@ -1089,15 +1091,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
     libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
     xz: '>=5.2.6,<6.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    lerc: '>=4.0.0,<5.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
   hash:
     md5: 66f03896ffbe1a110ffda05c7a856504
@@ -1109,15 +1111,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.20,<1.21.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.2.13,<2.0.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    lerc: '>=4.0.0,<5.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
   hash:
     md5: 6d1828c9039929e2f185c5fa9d133018
@@ -1153,8 +1155,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
   hash:
@@ -1167,10 +1169,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
+    pthread-stubs: ''
+    libgcc-ng: '>=12'
+    xorg-libxau: '>=1.0.11,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
   hash:
     md5: 151cba22b85a989c2d6ef9633ffee1e4
@@ -1185,8 +1187,8 @@ package:
     m2w64-gcc-libs: ''
     m2w64-gcc-libs-core: ''
     pthread-stubs: ''
-    xorg-libxau: '>=1.0.11,<2.0a0'
     xorg-libxdmcp: ''
+    xorg-libxau: '>=1.0.11,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
   hash:
     md5: 7c1217d3b075f195ab17370f2d550f5d
@@ -1210,11 +1212,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.3.1,<2.0a0'
+    libiconv: '>=1.17,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
   hash:
     md5: ed4d301f0d2149b34deb9c4fecafd836
@@ -1238,8 +1240,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
   hash:
@@ -1265,8 +1267,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    m2w64-gcc-libgfortran: ''
     m2w64-gcc-libs-core: ''
+    m2w64-gcc-libgfortran: ''
     m2w64-gmp: ''
     m2w64-libwinpthread-git: ''
     msys2-conda-epoch: '20160418'
@@ -1343,8 +1345,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    intel-openmp: 2024.*
     tbb: 2021.*
+    intel-openmp: 2024.*
   url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
   hash:
     md5: a17423859d3fb912c8f2e9797603ddb6
@@ -1379,13 +1381,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
     libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    liblapack: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py310hb13e2d6_0.conda
   hash:
     md5: 6593de64c935768b6bad3e19b3e978be
@@ -1397,14 +1399,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    liblapack: '>=3.9.0,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py310hf667824_0.conda
   hash:
     md5: 93e881c391880df90e74e43a4b67c16d
@@ -1417,10 +1419,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   hash:
     md5: 7f2e286780f072ed750df46dc2631138
@@ -1432,12 +1434,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libpng: '>=1.6.43,<1.7.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
   hash:
     md5: 7e7099ad94ac3b599808950cec30ad4e
@@ -1449,9 +1451,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
     libgcc-ng: '>=12'
+    __glibc: '>=2.17,<3.0.a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
   hash:
     md5: e1b454497f9f7c1147fdde4b53f1b512
@@ -1464,8 +1466,8 @@ package:
   platform: win-64
   dependencies:
     ca-certificates: ''
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
   hash:
@@ -1502,18 +1504,18 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
     libgcc-ng: '>=12'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    freetype: '>=2.12.1,<3.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxcb: '>=1.16,<1.17.0a0'
     libzlib: '>=1.3.1,<2.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
     openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
     tk: '>=8.6.13,<8.7.0a0'
+    libxcb: '>=1.16,<1.17.0a0'
+    lcms2: '>=2.16,<3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py310hebfe307_1.conda
   hash:
     md5: 8d357fd769e0e1a957f5916bdc8b1fa2
@@ -1525,20 +1527,20 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    freetype: '>=2.12.1,<3.0a0'
-    lcms2: '>=2.16,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.4.0,<2.0a0'
-    libxcb: '>=1.16,<1.17.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openjpeg: '>=2.5.2,<3.0a0'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    tk: '>=8.6.13,<8.7.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libwebp-base: '>=1.4.0,<2.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
+    lcms2: '>=2.16,<3.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    libxcb: '>=1.16,<1.17.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py310h3e38d90_1.conda
   hash:
     md5: ee35afda8b2154e7396fae5ca7fbea6b
@@ -1546,31 +1548,31 @@ package:
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: pip
-  version: '24.0'
+  version: '24.2'
   manager: conda
   platform: win-64
   dependencies:
     setuptools: ''
     wheel: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyhd8ed1ab_0.conda
   hash:
-    md5: f586ac1e56c8638b64f9c8122a7b8a67
-    sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+    md5: 6721aef6bfe5937abe70181545dd2c51
+    sha256: 15b480571a7a4d896aa187648cce99f98bac3926253f028f228d2e9e1cf7c1e1
   category: main
   optional: false
 - name: platformdirs
@@ -1662,10 +1664,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    annotated-types: '>=0.4.0'
-    pydantic-core: 2.20.1
     python: '>=3.7'
     typing-extensions: '>=4.6.1'
+    annotated-types: '>=0.4.0'
+    pydantic-core: 2.20.1
   url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
   hash:
     md5: 539a038a24a959662df1fcaa2cfc5c3e
@@ -1692,10 +1694,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    __glibc: '>=2.17,<3.0.a0'
     typing-extensions: '>=4.6.0,!=4.7.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.20.1-py310h42e942d_0.conda
   hash:
@@ -1708,12 +1710,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    typing-extensions: '>=4.6.0,!=4.7.0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    typing-extensions: '>=4.6.0,!=4.7.0'
   url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.20.1-py310hc226416_0.conda
   hash:
     md5: 99d16046cf146f48bf0b1d764f85397f
@@ -1749,16 +1751,16 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    astroid: '>=3.2.4,<3.3.0-dev0'
-    colorama: '>=0.4.5'
-    dill: '>=0.3.7'
-    isort: '>=4.2.5,<6,!=5.13.0'
-    mccabe: '>=0.6,<0.8'
-    platformdirs: '>=2.2.0'
     python: '>=3.8.0'
     tomli: '>=1.1.0'
-    tomlkit: '>=0.10.1'
     typing_extensions: '>=3.10.0'
+    platformdirs: '>=2.2.0'
+    tomlkit: '>=0.10.1'
+    colorama: '>=0.4.5'
+    mccabe: '>=0.6,<0.8'
+    dill: '>=0.3.7'
+    isort: '>=4.2.5,<6,!=5.13.0'
+    astroid: '>=3.2.4,<3.3.0-dev0'
   url: https://conda.anaconda.org/conda-forge/noarch/pylint-3.2.6-pyhd8ed1ab_0.conda
   hash:
     md5: 3bd59de4ef6ca2d96cfd5b36b33f9de9
@@ -1787,25 +1789,25 @@ package:
   category: dev
   optional: true
 - name: pytest
-  version: 8.3.1
+  version: 8.3.2
   manager: conda
   platform: linux-64
   dependencies:
-    colorama: ''
-    exceptiongroup: '>=1.0.0rc8'
-    iniconfig: ''
     packaging: ''
-    pluggy: <2,>=1.5
+    colorama: ''
+    iniconfig: ''
     python: '>=3.8'
+    exceptiongroup: '>=1.0.0rc8'
     tomli: '>=1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.1-pyhd8ed1ab_0.conda
+    pluggy: <2,>=1.5
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b6a3ab8559a42070c6b6c3063faea1ed
-    sha256: 23693df629c43f277b564abfcb321f6d9c4b6153a925ed004be7749bbc09ac3c
+    md5: e010a224b90f1f623a917c35addbb924
+    sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
   category: dev
   optional: true
 - name: pytest
-  version: 8.3.1
+  version: 8.3.2
   manager: conda
   platform: win-64
   dependencies:
@@ -1816,10 +1818,10 @@ package:
     exceptiongroup: '>=1.0.0rc8'
     tomli: '>=1'
     pluggy: <2,>=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: b6a3ab8559a42070c6b6c3063faea1ed
-    sha256: 23693df629c43f277b564abfcb321f6d9c4b6153a925ed004be7749bbc09ac3c
+    md5: e010a224b90f1f623a917c35addbb924
+    sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
   category: dev
   optional: true
 - name: pytest-cov
@@ -1827,10 +1829,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    coverage: '>=5.2.1'
-    pytest: '>=4.6'
-    python: '>=3.8'
     toml: ''
+    python: '>=3.8'
+    pytest: '>=4.6'
+    coverage: '>=5.2.1'
   url: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
   hash:
     md5: c54c0107057d67ddf077751339ec2c63
@@ -1857,22 +1859,22 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
-    libuuid: '>=2.38.1,<3.0a0'
-    libxcrypt: '>=4.4.36'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ncurses: '>=6.4.20240210,<7.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-    xz: '>=5.2.6,<6.0a0'
     pip: ''
+    tzdata: ''
+    libgcc-ng: '>=12'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    readline: '>=8.2,<9.0a0'
+    libuuid: '>=2.38.1,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    libffi: '>=3.4,<4.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    ncurses: '>=6.4.20240210,<7.0a0'
+    libxcrypt: '>=4.4.36'
+    libsqlite: '>=3.45.2,<4.0a0'
+    libnsl: '>=2.0.1,<2.1.0a0'
+    ld_impl_linux-64: '>=2.36.1'
   url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.14-hd12c33a_0_cpython.conda
   hash:
     md5: 2b4ba962994e8bd4be9ff5b64b75aff2
@@ -1884,17 +1886,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.2.1,<4.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
+    pip: ''
     tzdata: ''
     vc: '>=14.1,<15'
-    vc14_runtime: '>=14.16.27033'
+    libzlib: '>=1.2.13,<2.0.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
+    openssl: '>=3.2.1,<4.0a0'
+    vc14_runtime: '>=14.16.27033'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/python-3.10.14-h4de0772_0_cpython.conda
   hash:
     md5: 4a00e84f29d1eb418d84970598c444e1
@@ -1941,16 +1943,16 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
     libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    liblapack: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.19,<3'
-    python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    liblapack: '>=3.9.0,<4.0a0'
+    libgfortran5: '>=12.3.0'
+    libcblas: '>=3.9.0,<4.0a0'
+    numpy: <2.3
   url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py310h93e2701_1.conda
   hash:
     md5: c6b2a8134aa49940afe552f69bdef957
@@ -1962,15 +1964,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    numpy: '>=1.19,<3'
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.*
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    python_abi: 3.10.*
+    python: '>=3.10,<3.11.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    liblapack: '>=3.9.0,<4.0a0'
+    numpy: <2.3
+    libcblas: '>=3.9.0,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py310h46043a1_1.conda
   hash:
     md5: fef8eb0ea5459bcedd3f5ad41dabdaff
@@ -1978,27 +1980,27 @@ package:
   category: main
   optional: false
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: setuptools
-  version: 71.0.4
+  version: 72.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: ee78ac9c720d0d02fcfd420866b82ab1
-    sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+    md5: e06d4c26df4f958a8d38696f2c344d15
+    sha256: d239e7f1b1a5617eeadda4e91183592f5a15219e97e16bc721d7b0597ee89a80
   category: main
   optional: false
 - name: tbb
@@ -2006,10 +2008,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libhwloc: '>=2.11.1,<2.11.2.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libhwloc: '>=2.11.1,<2.11.2.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_3.conda
   hash:
     md5: a16e2a639e87c554abee5192ce6ee308
@@ -2034,8 +2036,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
   hash:
@@ -2349,10 +2351,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
+    ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.29.30139'
+    libzlib: '>=1.2.13,<2.0.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
   hash:
     md5: 9a17230f95733c04dc40a2b1e5491d74
@@ -2364,38 +2366,34 @@ package:
   manager: pip
   platform: linux-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoapps-utils
   version: 0.4.0a1
   manager: pip
   platform: win-64
   dependencies:
-    pillow: '>=10.3.0,<10.4.0'
     geoh5py: 0.10.0a1
-    h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
     scipy: '>=1.14.0,<1.15.0'
-  url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+  url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   hash:
-    sha256: e0cc6f5178fec820647f088f348a2f8db81c58a2
+    sha256: 2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoapps-utils@e0cc6f5178fec820647f088f348a2f8db81c58a2
+    url: git+https://github.com/MiraGeoscience/geoapps-utils@2bc1ea4dbea2a026ec37eb00180e8ed4423a9f6a
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -2406,13 +2404,13 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: 21ce81d279c206ce0a279377168ce50e0a35d3d2
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false
 - name: geoh5py
   version: 0.10.0a1
@@ -2423,11 +2421,11 @@ package:
     h5py: '>=3.2.1,<4.0.0'
     numpy: '>=1.26.0,<1.27.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   hash:
-    sha256: 21ce81d279c206ce0a279377168ce50e0a35d3d2
+    sha256: d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   category: main
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@21ce81d279c206ce0a279377168ce50e0a35d3d2
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@d351c4f3effbb3918f7b8f9e96f27a70202f2e8c
   optional: false


### PR DESCRIPTION
**GEOPY-1698 - relock conda env of repos to use fixed revision of geoapps-utils**
