### PR TITLE
DEVOPS-515: bump develop version in conda recipe too

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "octree-creation"
-release = "0.2.0-alpha.1"
+release = "0.3.0-alpha.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "octree-creation"
-release = "0.3.0-alpha.1"
+release = "0.2.0-alpha.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "octree-creation-app" %}
-{% set version = "0.2.0a1" %}
+{% set version = "0.3.0a1" %}
 
 package:
   name: {{ name|lower }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,7 @@ scipy = "~1.14.0"
 #------------------------------------
 
 #geoh5py = {version = "~0.10.0-alpha.1", source = "pypi", allow-prereleases = true}
-#geoh5py = {url = "https://github.com/MiraGeoscience/geoh5py/archive/refs/heads/develop.tar.gz"}
 geoh5py = {git = "https://github.com/MiraGeoscience/geoh5py.git", rev = "release/0.10.0"}
-#geoh5py = {url = "http://localhost:8888/geoh5py.tar.gz"}
 
 
 #geoapps-utils = { version = "~0.4.0-alpha.1", allow-prereleases = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octree-creation-app"
-version = "0.3.0-alpha.1"
+version = "0.2.0-alpha.1"
 license = "MIT"
 description = "Octree creation app."
 authors = ["Mira Geoscience <support@mirageoscience.com>"]
@@ -52,12 +52,9 @@ scipy = "~1.14.0"
 #------------------------------------
 
 #geoh5py = {version = "~0.10.0-alpha.1", source = "pypi", allow-prereleases = true}
-#geoh5py = {url = "https://github.com/MiraGeoscience/geoh5py/archive/refs/heads/develop.tar.gz"}
 geoh5py = {git = "https://github.com/MiraGeoscience/geoh5py.git", rev = "release/0.10.0"}
-#geoh5py = {url = "http://localhost:8888/geoh5py.tar.gz"}
 
-
-#geoapps-utils = { version = "~0.4.0-alpha.1", allow-prereleases = true}
+#geoapps-utils = { version = "~0.4.0-alpha.1", source = "pypi", allow-prereleases = true}
 geoapps-utils = {git = "https://github.com/MiraGeoscience/geoapps-utils.git", rev = "release/0.4.0"}
 
 ## indirect dependencies, forcing them here for installation through Conda not pip
@@ -80,9 +77,6 @@ Pygments = "*"
 pylint = "*"
 pytest = "*"
 pytest-cov = "*"
-pyyaml = '*'
-jinja2 = '*'
-packaging = '*'
 tomli = "*"
 
 [tool.conda-lock]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octree-creation-app"
-version = "0.2.0-alpha.1"
+version = "0.3.0-alpha.1"
 license = "MIT"
 description = "Octree creation app."
 authors = ["Mira Geoscience <support@mirageoscience.com>"]
@@ -52,9 +52,12 @@ scipy = "~1.14.0"
 #------------------------------------
 
 #geoh5py = {version = "~0.10.0-alpha.1", source = "pypi", allow-prereleases = true}
+#geoh5py = {url = "https://github.com/MiraGeoscience/geoh5py/archive/refs/heads/develop.tar.gz"}
 geoh5py = {git = "https://github.com/MiraGeoscience/geoh5py.git", rev = "release/0.10.0"}
+#geoh5py = {url = "http://localhost:8888/geoh5py.tar.gz"}
 
-#geoapps-utils = { version = "~0.4.0-alpha.1", source = "pypi", allow-prereleases = true}
+
+#geoapps-utils = { version = "~0.4.0-alpha.1", allow-prereleases = true}
 geoapps-utils = {git = "https://github.com/MiraGeoscience/geoapps-utils.git", rev = "release/0.4.0"}
 
 ## indirect dependencies, forcing them here for installation through Conda not pip
@@ -77,6 +80,9 @@ Pygments = "*"
 pylint = "*"
 pytest = "*"
 pytest-cov = "*"
+pyyaml = '*'
+jinja2 = '*'
+packaging = '*'
 tomli = "*"
 
 [tool.conda-lock]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ scipy = "~1.14.0"
 #geoh5py = {version = "~0.10.0-alpha.1", source = "pypi", allow-prereleases = true}
 geoh5py = {git = "https://github.com/MiraGeoscience/geoh5py.git", rev = "release/0.10.0"}
 
-
-#geoapps-utils = { version = "~0.4.0-alpha.1", allow-prereleases = true}
+#geoapps-utils = { version = "~0.4.0-alpha.1", source = "pypi", allow-prereleases = true}
 geoapps-utils = {git = "https://github.com/MiraGeoscience/geoapps-utils.git", rev = "release/0.4.0"}
 
 ## indirect dependencies, forcing them here for installation through Conda not pip


### PR DESCRIPTION
**DEVOPS-515 - release branches to prepare distrib for Analyst 4.5**
also reverting revert of version bump of https://github.com/MiraGeoscience/octree-creation-app/pull/61