### PR TITLE
GEOPY-1862: for pypi, use dedicated package.rst as long description (readme field) instead of README.rst

### DIFF
--- a/octree_creation_app/params.py
+++ b/octree_creation_app/params.py
@@ -138,8 +138,8 @@ class OctreeParams(BaseData):
 
         return out
 
-    @staticmethod
-    def collect_input_from_dict(base_model: type[BaseModel], data: dict[str, Any]):
+    @classmethod
+    def collect_input_from_dict(cls, base_model: type[BaseModel], data: dict[str, Any]):
         """
         Recursively replace BaseModel objects with dictionary of 'data' values.
 
@@ -148,7 +148,7 @@ class OctreeParams(BaseData):
         :param data: Dictionary of parameters and values without nesting structure.
         """
 
-        update = super().collect_input_from_dict(base_model, data)
+        update = cls.super().collect_input_from_dict(base_model, data)
         update["refinements"] = collect_refinements_from_dict(data)
 
         return update

--- a/octree_creation_app/params.py
+++ b/octree_creation_app/params.py
@@ -148,7 +148,7 @@ class OctreeParams(BaseData):
         :param data: Dictionary of parameters and values without nesting structure.
         """
 
-        update = cls.super().collect_input_from_dict(base_model, data)
+        update = super().collect_input_from_dict(base_model, data)
         update["refinements"] = collect_refinements_from_dict(data)
 
         return update

--- a/package.rst
+++ b/package.rst
@@ -1,0 +1,66 @@
+geoapps
+================
+
+The **geoapps** project has been created for the development and sharing of open-source
+applications in geoscience, directly leverage the powerful visualization capabilities of
+`Geoscience ANALYST <https://mirageoscience.com/mining-industry-software/geoscience-analyst/>`_ along with open-source code from the Python ecosystem.
+
+
+Installation
+^^^^^^^^^^^^
+**geoapps** is currently written for Python 3.10 or higher.
+
+Install **geoapps** from PyPI::
+
+    $ pip install geoapps
+
+
+Feedback
+^^^^^^^^
+Have comments or suggestions? Submit feedback.
+All the content can be found on the github_ repository.
+
+.. _github: https://github.com/MiraGeoscience/geoapps
+
+
+Visit `Mira Geoscience website <https://mirageoscience.com/>`_ to learn more about our products
+and services.
+
+
+License
+^^^^^^^
+MIT License
+
+Copyright (c) 2020-2025 Mira Geoscience
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Third Party Software
+^^^^^^^^^^^^^^^^^^^^
+The geoapps Software may provide links to third party libraries or code (collectively “Third Party Software”)
+to implement various functions. Third Party Software does not comprise part of the Software.
+The use of Third Party Software is governed by the terms of such software license(s).
+Third Party Software notices and/or additional terms and conditions are located in the
+`THIRD_PARTY_SOFTWARE.rst`_ file.
+
+.. _THIRD_PARTY_SOFTWARE.rst: ./docs/source/THIRD_PARTY_SOFTWARE.rst
+
+Copyright
+^^^^^^^^^
+Copyright (c) 2024-2025 Mira Geoscience Ltd.

--- a/package.rst
+++ b/package.rst
@@ -1,18 +1,18 @@
-geoapps
-================
+Octree-creation-app
+===================
 
-The **geoapps** project has been created for the development and sharing of open-source
-applications in geoscience, directly leverage the powerful visualization capabilities of
-`Geoscience ANALYST <https://mirageoscience.com/mining-industry-software/geoscience-analyst/>`_ along with open-source code from the Python ecosystem.
+The **octree-creation-app** package lets users create Octree mesh objects with
+local refinements using the `SimPEG.discretize <https://discretize.simpeg.xyz/en/latest/>`_ package. The refinements can be
+performed on any number of ``Objects`` stored in a ``geoh5`` file.
 
 
 Installation
 ^^^^^^^^^^^^
-**geoapps** is currently written for Python 3.10 or higher.
+**octree-creation-app** is currently written for Python 3.10 or higher.
 
-Install **geoapps** from PyPI::
+Install **octree-creation-app** from PyPI::
 
-    $ pip install geoapps
+    $ pip install octree-creation-app
 
 
 Feedback
@@ -20,7 +20,7 @@ Feedback
 Have comments or suggestions? Submit feedback.
 All the content can be found on the github_ repository.
 
-.. _github: https://github.com/MiraGeoscience/geoapps
+.. _github: https://github.com/MiraGeoscience/octree-creation-app
 
 
 Visit `Mira Geoscience website <https://mirageoscience.com/>`_ to learn more about our products
@@ -53,7 +53,7 @@ SOFTWARE.
 
 Third Party Software
 ^^^^^^^^^^^^^^^^^^^^
-The geoapps Software may provide links to third party libraries or code (collectively “Third Party Software”)
+The octree-creation-app Software may provide links to third party libraries or code (collectively “Third Party Software”)
 to implement various functions. Third Party Software does not comprise part of the Software.
 The use of Third Party Software is governed by the terms of such software license(s).
 Third Party Software notices and/or additional terms and conditions are located in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ maintainers = ["Dominique Fournier <dominiquef@mirageoscience.com>"]
 repository = "https://github.com/MiraGeoscience/octree-creation-app"
 documentation  = "https://mirageoscience-octree-creation-app.readthedocs-hosted.com/"
 homepage = "https://www.mirageoscience.com/mining-industry-software/python-integration/"
-
-readme = "README.rst"
+readme = "package.rst"
 
 packages = [
      { include = "octree_creation_app" },
@@ -21,7 +20,6 @@ include = [
     { path = "COPYING.LESSER" },
     { path = "LICENSE" },
     { path = "README.rst" },
-    { path = "THIRD_PARTY_SOFTWARE.rst" },
     { path = "docs/**/THIRD_PARTY_SOFTWARE.rst" },
 ]
 


### PR DESCRIPTION
**GEOPY-1862 - for pypi, use dedicated package.rst as long description (readme field) instead of README.rst**
